### PR TITLE
Differentiate between points and performance points calculations

### DIFF
--- a/analytics/football/league_table.py
+++ b/analytics/football/league_table.py
@@ -14,12 +14,13 @@ class GamePOV:
 
 
 class LeagueTableRow:
-    def __init__(self, team: Team, game_povs=None):
+    def __init__(self, team: Team, points_deduction=0, game_povs=None, wins=0, draws=0):
         if game_povs is None:
             game_povs = []
         self.team = team
-        self.wins = 0
-        self.draws = 0
+        self.points_deduction = points_deduction
+        self.wins = wins
+        self.draws = draws
         self.losses = 0
         self.scored = 0
         self.conceded = 0
@@ -32,6 +33,12 @@ class LeagueTableRow:
         return self.wins + self.draws + self.losses
 
     def points(self):
+        return self.performance_points() - self.points_deduction
+
+    def has_points_deducted(self):
+        return self.points_deduction > 0
+
+    def performance_points(self):
         return 3 * self.wins + self.draws
 
     def goal_difference(self):

--- a/analytics/football/templates/league_table.html
+++ b/analytics/football/templates/league_table.html
@@ -44,7 +44,7 @@
                     <td>{{ row.scored }}</td>
                     <td>{{ row.conceded }}</td>
                     <td>{{ row.goal_difference }}</td>
-                    <td>{{ row.points }}</td>
+                    <td>{{ row.points }}{% if row.has_points_deducted %}*{% endif %}</td>
                     <td>{{ row.xg }}</td>
                     <td>{{ row.xg_against }}</td>
                     <td>{{ row.x_points }}</td>

--- a/analytics/football/tests/test_league_table_row.py
+++ b/analytics/football/tests/test_league_table_row.py
@@ -124,7 +124,7 @@ class LeagueTableRowTestCase(TestCase):
     def test_most_recent_away_games(self):
         """Finds most recent X away games"""
         charlton = Team(name='Charlton')
-        league_table_row = LeagueTableRow(Team(name='Charlton'))
+        league_table_row = LeagueTableRow(charlton)
         self.assertEqual(league_table_row.most_recent_away_games(), [])
 
         opposition1 = Team(name='Opposition 1')
@@ -160,3 +160,21 @@ class LeagueTableRowTestCase(TestCase):
         self.assertNotIn(game_pov5, most_recent_away_games)
         self.assertIn(game_pov4, most_recent_away_games)
         self.assertIn(game_pov6, most_recent_away_games)
+
+    def test_has_points_deducted_yes(self):
+        league_table_row = LeagueTableRow(Team(name='Charlton'), points_deduction=2)
+        self.assertTrue(league_table_row.has_points_deducted())
+
+    def test_has_points_deducted_no(self):
+        league_table_row = LeagueTableRow(Team(name='Charlton'), points_deduction=0)
+        self.assertFalse(league_table_row.has_points_deducted())
+
+    def test_points_with_points_deduction(self):
+        league_table_row = LeagueTableRow(Team(name='Charlton'), points_deduction=16, wins=2, draws=1)
+        self.assertEqual(-9, league_table_row.points())
+        self.assertEqual(7, league_table_row.performance_points())
+
+    def test_points_with_no_points_deduction(self):
+        league_table_row = LeagueTableRow(Team(name='Charlton'), points_deduction=0, wins=4, draws=2)
+        self.assertEqual(14, league_table_row.points())
+        self.assertEqual(14, league_table_row.performance_points())


### PR DESCRIPTION
Calculate fixture difficulty based on points with no points deductions, but use points deduction to display the actual league table.
