### PR TITLE
Points per game difficulty

### DIFF
--- a/analytics/football/league_table.py
+++ b/analytics/football/league_table.py
@@ -47,6 +47,9 @@ class LeagueTableRow:
     def performance_points_per_game(self):
         return self.performance_points() / len(self.results)
 
+    def x_points_per_game(self):
+        return self.x_points / len(self.results)
+
     def goal_difference(self):
         return self.scored - self.conceded
 

--- a/analytics/football/league_table.py
+++ b/analytics/football/league_table.py
@@ -44,6 +44,9 @@ class LeagueTableRow:
     def performance_points(self):
         return 3 * self.wins + self.draws
 
+    def performance_points_per_game(self):
+        return self.performance_points() / len(self.results)
+
     def goal_difference(self):
         return self.scored - self.conceded
 

--- a/analytics/football/templates/league_table.html
+++ b/analytics/football/templates/league_table.html
@@ -7,7 +7,7 @@
 <div class="flex flex-col items-center mx-10 md:mx-20">
     <h1 class="prose-2xl mb-4">Football League Table</h1>
     <a href="{% url 'metrics_management' competition_name season_name %}" class="link link-primary">Metrics management</a>
-    <table class="table table-zebra table-lg">
+    <table class="table table-zebra table-xs">
         <thead>
             <tr>
                 <th rowspan="2"></th>
@@ -17,19 +17,24 @@
             </tr>
             <tr>
                 <th>P</th>
+                <th>W</th>
+                <th>D</th>
+                <th>L</th>
                 <th>F</th>
                 <th>A</th>
                 <th>GD</th>
                 <th>Pts</th>
+                <th>PPts/g</th>
                 <th>xG</th>
                 <th>xGA</th>
-                <th>xPoints</th>
-                <th>Diff: Pos</th>
-                <th>Diff: xPts</th>
+                <th>xPts</th>
+                <th>xPts/g</th>
+                <th>Diff: PPts/g</th>
+                <th>Diff: xPts/g</th>
                 <th>Diff: Weighted</th>
                 <th>Games remaining</th>
-                <th>Diff: Pos</th>
-                <th>Diff: xPts</th>
+                <th>Diff: PPts/g</th>
+                <th>Diff: xPts/g</th>
                 <th>Diff: Weighted</th>
             </tr>
         </thead>
@@ -40,42 +45,47 @@
                     <td>{{ forloop.counter }}</td>
                     <td>{{ row.team.name }}</td>
                     <td>{{ row.games_played }}</td>
+                    <td>{{ row.wins }}</td>
+                    <td>{{ row.draws }}</td>
+                    <td>{{ row.losses }}</td>
                     <td>{{ row.scored }}</td>
                     <td>{{ row.conceded }}</td>
                     <td>{{ row.goal_difference }}</td>
                     <td>{{ row.points }}{% if row.has_points_deducted %}*{% endif %}</td>
+                    <td>{{ row.performance_points_per_game|floatformat:"2" }}</td>
                     <td>{{ row.xg }}</td>
                     <td>{{ row.xg_against }}</td>
                     <td>{{ row.x_points }}</td>
+                    <td>{{ row.x_points_per_game|floatformat:"2" }}</td>
                     {% with traditional_result_difficulty=result_difficulties.traditional|hash:row.team %}
                         <td style="background-color: {{ traditional_result_difficulty|difficulty_colour }}">
-                            {{ traditional_result_difficulty|floatformat:"3" }}
+                            {{ traditional_result_difficulty|floatformat:"2" }}
                         </td>
                     {% endwith %}
                     {% with x_points_result_difficulty=result_difficulties.x_points|hash:row.team %}
                         <td style="background-color: {{ x_points_result_difficulty|difficulty_colour }}">
-                            {{ x_points_result_difficulty|floatformat:"3" }}
+                            {{ x_points_result_difficulty|floatformat:"2" }}
                         </td>
                     {% endwith %}
                     {% with weighted_result_difficulty=result_difficulties.weighted|hash:row.team %}
                         <td style="background-color: {{ weighted_result_difficulty|difficulty_colour }}">
-                            {{ weighted_result_difficulty|floatformat:"3" }}
+                            {{ weighted_result_difficulty|floatformat:"2" }}
                         </td>
                     {% endwith %}
                     <td>{{ row.games_remaining }}</td>
                     {% with traditional_fixture_difficulty=fixture_difficulties.traditional|hash:row.team %}
                         <td style="background-color: {{ traditional_fixture_difficulty|difficulty_colour }}">
-                            {{ traditional_fixture_difficulty|floatformat:"3" }}
+                            {{ traditional_fixture_difficulty|floatformat:"2" }}
                         </td>
                     {% endwith %}
                     {% with x_points_fixture_difficulty=fixture_difficulties.x_points|hash:row.team %}
                         <td style="background-color: {{ x_points_fixture_difficulty|difficulty_colour }}">
-                            {{ x_points_fixture_difficulty|floatformat:"3" }}
+                            {{ x_points_fixture_difficulty|floatformat:"2" }}
                         </td>
                     {% endwith %}
                     {% with weighted_fixture_difficulty=fixture_difficulties.weighted|hash:row.team %}
                         <td style="background-color: {{ weighted_fixture_difficulty|difficulty_colour }}">
-                            {{ weighted_fixture_difficulty|floatformat:"3" }}
+                            {{ weighted_fixture_difficulty|floatformat:"2" }}
                         </td>
                     {% endwith %}
                 </tr>

--- a/analytics/football/tests/test_league_table_row.py
+++ b/analytics/football/tests/test_league_table_row.py
@@ -8,7 +8,7 @@ class LeagueTableRowTestCase(TestCase):
     def test_games_played(self):
         """Games played is wins + draws + losses"""
         charlton = Team(name='Charlton')
-        league_table_row = LeagueTableRow(Team(name='Charlton'))
+        league_table_row = LeagueTableRow(charlton)
         self.assertEqual(league_table_row.games_played(), 0)
 
         opposition1 = Team(name='Opposition 1')
@@ -178,3 +178,17 @@ class LeagueTableRowTestCase(TestCase):
         league_table_row = LeagueTableRow(Team(name='Charlton'), points_deduction=0, wins=4, draws=2)
         self.assertEqual(14, league_table_row.points())
         self.assertEqual(14, league_table_row.performance_points())
+
+    def test_performance_points_per_game(self):
+        charlton = Team(name='Charlton')
+        league_table_row = LeagueTableRow(charlton)
+
+        opposition1 = Team(name='Opposition 1')
+        opposition2 = Team(name='Opposition 2')
+        opposition3 = Team(name='Opposition 3')
+        opposition4 = Team(name='Opposition 4')
+        league_table_row.add_result(GamePOV(charlton, opposition1, scored=3, conceded=0, is_home=True))
+        league_table_row.add_result(GamePOV(charlton, opposition2, scored=0, conceded=1, is_home=False))
+        league_table_row.add_result(GamePOV(charlton, opposition3, scored=1, conceded=0, is_home=True))
+        league_table_row.add_result(GamePOV(charlton, opposition4, scored=0, conceded=0, is_home=True))
+        self.assertEqual(1.75, league_table_row.performance_points_per_game())

--- a/analytics/football/tests/test_league_table_row.py
+++ b/analytics/football/tests/test_league_table_row.py
@@ -191,4 +191,21 @@ class LeagueTableRowTestCase(TestCase):
         league_table_row.add_result(GamePOV(charlton, opposition2, scored=0, conceded=1, is_home=False))
         league_table_row.add_result(GamePOV(charlton, opposition3, scored=1, conceded=0, is_home=True))
         league_table_row.add_result(GamePOV(charlton, opposition4, scored=0, conceded=0, is_home=True))
+        # 7 / 4 = 1.75
         self.assertEqual(1.75, league_table_row.performance_points_per_game())
+
+    def test_x_points_per_game(self):
+        charlton = Team(name='Charlton')
+        league_table_row = LeagueTableRow(charlton)
+        league_table_row.x_points = 9.3
+        opposition1 = Team(name='Opposition 1')
+        opposition2 = Team(name='Opposition 2')
+        opposition3 = Team(name='Opposition 3')
+        opposition4 = Team(name='Opposition 4')
+        league_table_row.add_result(GamePOV(charlton, opposition1, scored=3, conceded=0, is_home=True))
+        league_table_row.add_result(GamePOV(charlton, opposition2, scored=0, conceded=1, is_home=False))
+        league_table_row.add_result(GamePOV(charlton, opposition3, scored=1, conceded=0, is_home=True))
+        league_table_row.add_result(GamePOV(charlton, opposition4, scored=0, conceded=0, is_home=True))
+        league_table_row.add_result(GamePOV(charlton, opposition1, scored=0, conceded=0, is_home=False))
+        # 9.3 / 5 = 1.86
+        self.assertEqual(1.86, league_table_row.x_points_per_game())

--- a/analytics/football/views.py
+++ b/analytics/football/views.py
@@ -116,15 +116,15 @@ def calculate_contextual_league_table(stage, games, competition_name, season_nam
         team_row.xg_against = team_metrics.xg_against
         team_row.x_points = team_metrics.x_points
 
-    rows_sorted_by_performance_points = sorted(
-        rows_by_team_name.values(),
-        key=lambda row: (row.performance_points(), row.goal_difference(), row.scored, row.team.name),
-        reverse=True
-    )
-
     rows_sorted_by_points = sorted(
         rows_by_team_name.values(),
         key=lambda row: (row.points(), row.goal_difference(), row.scored, row.team.name),
+        reverse=True
+    )
+
+    rows_sorted_by_performance_points = sorted(
+        rows_by_team_name.values(),
+        key=lambda row: (row.performance_points_per_game(), row.goal_difference(), row.scored, row.team.name),
         reverse=True
     )
 

--- a/analytics/football/views.py
+++ b/analytics/football/views.py
@@ -130,7 +130,7 @@ def calculate_contextual_league_table(stage, games, competition_name, season_nam
 
     rows_sorted_by_x_points = sorted(
         rows_by_team_name.values(),
-        key=lambda row: (row.x_points, row.xg_difference()),
+        key=lambda row: (row.x_points_per_game(), row.xg_difference()),
         reverse=True
     )
 


### PR DESCRIPTION
Calculate result/fixture difficulty based on points per game instead of total points to cope with teams with games in hand. This is still a bit flawed, but is an iterative improvement.