### PR TITLE
Calculate difficulty of most recent 5 games and upcoming fixtures

### DIFF
--- a/analytics/football/league_table.py
+++ b/analytics/football/league_table.py
@@ -87,6 +87,11 @@ class LeagueTableRow:
             return []
         return self.results[-limit:]
 
+    def upcoming_games(self, limit = 5):
+        if limit <= 0:
+            return []
+        return self.fixtures[:limit]
+
     def most_recent_home_games(self, limit = 5):
         return self.most_recent_games_matching_criteria(is_home=True, limit=limit)
 

--- a/analytics/football/modelling/game_chooser.py
+++ b/analytics/football/modelling/game_chooser.py
@@ -14,3 +14,11 @@ class FixturesChooser(GameChooser):
 class ResultsChooser(GameChooser):
     def choose_games(self, league_table_row: LeagueTableRow):
         return league_table_row.results
+
+class RecentFormChooser(GameChooser):
+    def choose_games(self, league_table_row: LeagueTableRow):
+        return league_table_row.most_recent_games(5)
+
+class UpcomingGamesChooser(GameChooser):
+    def choose_games(self, league_table_row: LeagueTableRow):
+        return league_table_row.upcoming_games(5)

--- a/analytics/football/templates/league_table.html
+++ b/analytics/football/templates/league_table.html
@@ -13,8 +13,8 @@
             <tr>
                 <th rowspan="2"></th>
                 <th rowspan="2"></th>
-                <th colspan="17">Results</th>
-                <th colspan="2">Fixtures</th>
+                <th colspan="18">Results</th>
+                <th colspan="3">Fixtures</th>
             </tr>
             <tr>
                 <th>P</th>
@@ -34,8 +34,10 @@
                 <th>xPts/g</th>
                 <th>Rating</th>
                 <th>SoS</th>
+                <th>Form</th>
                 <th>Games remaining</th>
                 <th>SoS</th>
+                <th>Upcoming</th>
             </tr>
         </thead>
         <tbody>
@@ -67,10 +69,20 @@
                             {{ result_sos|floatformat:"2" }}
                         </td>
                     {% endwith %}
+                    {% with form_sos=result_difficulties.form|hash:row.team %}
+                        <td style="background-color: {{ form_sos|reverse_difficulty_colour }}">
+                            {{ form_sos|floatformat:"2" }}
+                        </td>
+                    {% endwith %}
                     <td>{{ row.games_remaining }}</td>
                     {% with fixture_sos=fixture_difficulties.sos|hash:row.team %}
                         <td style="background-color: {{ fixture_sos|reverse_difficulty_colour }}">
                             {{ fixture_sos|floatformat:"2" }}
+                        </td>
+                    {% endwith %}
+                    {% with upcoming_sos=fixture_difficulties.upcoming|hash:row.team %}
+                        <td style="background-color: {{ upcoming_sos|reverse_difficulty_colour }}">
+                            {{ upcoming_sos|floatformat:"2" }}
                         </td>
                     {% endwith %}
                 </tr>

--- a/analytics/football/tests/test_league_table_row.py
+++ b/analytics/football/tests/test_league_table_row.py
@@ -121,6 +121,46 @@ class LeagueTableRowTestCase(TestCase):
         self.assertIn(game_pov5, most_recent_home_games)
         self.assertIn(game_pov6, most_recent_home_games)
 
+    def test_upcoming_games(self):
+        """Test upcoming X games"""
+        charlton = Team(name='Charlton')
+        league_table_row = LeagueTableRow(Team(name='Charlton'))
+        self.assertEqual(league_table_row.upcoming_games(), [])
+
+        opposition1 = Team(name='Opposition 1')
+        opposition2 = Team(name='Opposition 2')
+        opposition3 = Team(name='Opposition 3')
+        opposition4 = Team(name='Opposition 4')
+        opposition5 = Team(name='Opposition 5')
+        opposition6 = Team(name='Opposition 6')
+        game_pov1 = GamePOV(charlton, opposition1, scored=1, conceded=0, is_home=True)
+        game_pov2 = GamePOV(charlton, opposition2, scored=1, conceded=1, is_home=True)
+        game_pov3 = GamePOV(charlton, opposition3, scored=0, conceded=1, is_home=True)
+        game_pov4 = GamePOV(charlton, opposition4, scored=3, conceded=3, is_home=False)
+        game_pov5 = GamePOV(charlton, opposition5, scored=2, conceded=0, is_home=True)
+        game_pov6 = GamePOV(charlton, opposition6, scored=2, conceded=1, is_home=True)
+        league_table_row.add_fixture(game_pov1)
+        league_table_row.add_fixture(game_pov2)
+        league_table_row.add_fixture(game_pov3)
+        league_table_row.add_fixture(game_pov4)
+        league_table_row.add_fixture(game_pov5)
+        league_table_row.add_fixture(game_pov6)
+
+        self.assertEqual(len(league_table_row.upcoming_games(1)), 1)
+        self.assertEqual(len(league_table_row.upcoming_games(2)), 2)
+        self.assertEqual(len(league_table_row.upcoming_games(3)), 3)
+        self.assertEqual(len(league_table_row.upcoming_games(4)), 4)
+        self.assertEqual(len(league_table_row.upcoming_games(5)), 5)
+        self.assertEqual(len(league_table_row.upcoming_games(6)), 5)
+
+        upcoming_games = league_table_row.upcoming_games(3)
+        self.assertNotIn(game_pov4, upcoming_games)
+        self.assertNotIn(game_pov5, upcoming_games)
+        self.assertNotIn(game_pov6, upcoming_games)
+        self.assertIn(game_pov1, upcoming_games)
+        self.assertIn(game_pov2, upcoming_games)
+        self.assertIn(game_pov3, upcoming_games)
+
     def test_most_recent_away_games(self):
         """Finds most recent X away games"""
         charlton = Team(name='Charlton')

--- a/analytics/football/tests/test_league_table_row.py
+++ b/analytics/football/tests/test_league_table_row.py
@@ -151,7 +151,8 @@ class LeagueTableRowTestCase(TestCase):
         self.assertEqual(len(league_table_row.upcoming_games(3)), 3)
         self.assertEqual(len(league_table_row.upcoming_games(4)), 4)
         self.assertEqual(len(league_table_row.upcoming_games(5)), 5)
-        self.assertEqual(len(league_table_row.upcoming_games(6)), 5)
+        self.assertEqual(len(league_table_row.upcoming_games(6)), 6)
+        self.assertEqual(len(league_table_row.upcoming_games(7)), 6)
 
         upcoming_games = league_table_row.upcoming_games(3)
         self.assertNotIn(game_pov4, upcoming_games)


### PR DESCRIPTION
Reusing SoS calculations to see which teams (comparatively) have the easiest and hardest most recent and upcoming games